### PR TITLE
[IMP] moved report under proper menu

### DIFF
--- a/l10n_it_vat_registries/account_tax_registry_view.xml
+++ b/l10n_it_vat_registries/account_tax_registry_view.xml
@@ -15,7 +15,7 @@
                 </form>
             </field>
         </record>
-        
+
         <record id="action_account_tax_registry_form" model="ir.actions.act_window">
             <field name="name">VAT registries</field>
             <field name="res_model">account.tax.registry</field>

--- a/l10n_it_vat_registries/i18n/it.po
+++ b/l10n_it_vat_registries/i18n/it.po
@@ -170,8 +170,8 @@ msgstr "Layout"
 
 #. module: l10n_it_vat_registries
 #: view:wizard.registro.iva:l10n_it_vat_registries.wizard_registro_iva
-msgid "Layuot"
-msgstr "Layuot"
+msgid "Layout"
+msgstr "Layout"
 
 #. module: l10n_it_vat_registries
 #: field:wizard.registro.iva,message:0

--- a/l10n_it_vat_registries/i18n/it.po
+++ b/l10n_it_vat_registries/i18n/it.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-31 12:04+0000\n"
-"PO-Revision-Date: 2015-08-31 12:04+0000\n"
+"POT-Creation-Date: 2015-10-02 22:02+0000\n"
+"PO-Revision-Date: 2015-10-02 22:02+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -36,7 +36,7 @@ msgid "CAUS."
 msgstr "CAUS."
 
 #. module: l10n_it_vat_registries
-#: code:addons/l10n_it_vat_registries/vat_registry.py:182
+#: code:addons/l10n_it_vat_registries/vat_registry.py:183
 #, python-format
 msgid "Can't compute base amount for tax %s"
 msgstr "Impossibile calcolare l'imponibile per l'imposta %s"
@@ -87,11 +87,6 @@ msgstr "DT FATT."
 
 #. module: l10n_it_vat_registries
 #: view:website:l10n_it_vat_registries.report_registro_iva
-msgid "Data registrazione"
-msgstr "Data registrazione"
-
-#. module: l10n_it_vat_registries
-#: view:website:l10n_it_vat_registries.report_registro_iva
 msgid "Descrizione"
 msgstr "Descrizione"
 
@@ -121,11 +116,6 @@ msgstr "ID"
 #: view:website:l10n_it_vat_registries.report_registro_iva
 msgid "Imponibile"
 msgstr "Imponibile"
-
-#. module: l10n_it_vat_registries
-#: view:website:l10n_it_vat_registries.report_registro_iva
-msgid "Importo"
-msgstr "Importo"
 
 #. module: l10n_it_vat_registries
 #: view:website:l10n_it_vat_registries.report_registro_iva
@@ -217,11 +207,6 @@ msgstr "Nessun documento trovato per la selezione corrente"
 
 #. module: l10n_it_vat_registries
 #: view:website:l10n_it_vat_registries.report_registro_iva
-msgid "Numero"
-msgstr "Numero"
-
-#. module: l10n_it_vat_registries
-#: view:website:l10n_it_vat_registries.report_registro_iva
 msgid "P.IVA"
 msgstr "P.IVA"
 
@@ -283,15 +268,15 @@ msgid "Tax amount sign"
 msgstr "Segno importo imposta"
 
 #. module: l10n_it_vat_registries
-#: code:addons/l10n_it_vat_registries/vat_registry.py:239
+#: code:addons/l10n_it_vat_registries/vat_registry.py:240
 #, python-format
 msgid "Tax code %s is not linked to 1 and only 1 tax"
 msgstr "Tax code %s is not linked to 1 and only 1 tax"
 
 #. module: l10n_it_vat_registries
-#: view:website:l10n_it_vat_registries.report_registro_iva
-msgid "Totale"
-msgstr "Totale"
+#: model:ir.ui.menu,name:l10n_it_vat_registries.menu_finance_legal_statement_taxes
+msgid "Taxes"
+msgstr "Imposte"
 
 #. module: l10n_it_vat_registries
 #: view:website:l10n_it_vat_registries.report_registro_iva
@@ -339,3 +324,4 @@ msgstr "E' possibile raggruppare diversi sezionali in un unico registro. Nel wiz
 #: view:wizard.registro.iva:l10n_it_vat_registries.wizard_registro_iva
 msgid "or"
 msgstr "o"
+

--- a/l10n_it_vat_registries/i18n/l10n_it_vat_registries.pot
+++ b/l10n_it_vat_registries/i18n/l10n_it_vat_registries.pot
@@ -165,7 +165,7 @@ msgstr ""
 
 #. module: l10n_it_vat_registries
 #: view:wizard.registro.iva:l10n_it_vat_registries.wizard_registro_iva
-msgid "Layuot"
+msgid "Layout"
 msgstr ""
 
 #. module: l10n_it_vat_registries

--- a/l10n_it_vat_registries/i18n/l10n_it_vat_registries.pot
+++ b/l10n_it_vat_registries/i18n/l10n_it_vat_registries.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-31 12:03+0000\n"
-"PO-Revision-Date: 2015-08-31 12:03+0000\n"
+"POT-Creation-Date: 2015-10-02 22:02+0000\n"
+"PO-Revision-Date: 2015-10-02 22:02+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31,7 +31,7 @@ msgid "CAUS."
 msgstr ""
 
 #. module: l10n_it_vat_registries
-#: code:addons/l10n_it_vat_registries/vat_registry.py:182
+#: code:addons/l10n_it_vat_registries/vat_registry.py:183
 #, python-format
 msgid "Can't compute base amount for tax %s"
 msgstr ""
@@ -82,11 +82,6 @@ msgstr ""
 
 #. module: l10n_it_vat_registries
 #: view:website:l10n_it_vat_registries.report_registro_iva
-msgid "Data registrazione"
-msgstr ""
-
-#. module: l10n_it_vat_registries
-#: view:website:l10n_it_vat_registries.report_registro_iva
 msgid "Descrizione"
 msgstr ""
 
@@ -115,11 +110,6 @@ msgstr ""
 #. module: l10n_it_vat_registries
 #: view:website:l10n_it_vat_registries.report_registro_iva
 msgid "Imponibile"
-msgstr ""
-
-#. module: l10n_it_vat_registries
-#: view:website:l10n_it_vat_registries.report_registro_iva
-msgid "Importo"
 msgstr ""
 
 #. module: l10n_it_vat_registries
@@ -212,11 +202,6 @@ msgstr ""
 
 #. module: l10n_it_vat_registries
 #: view:website:l10n_it_vat_registries.report_registro_iva
-msgid "Numero"
-msgstr ""
-
-#. module: l10n_it_vat_registries
-#: view:website:l10n_it_vat_registries.report_registro_iva
 msgid "P.IVA"
 msgstr ""
 
@@ -278,14 +263,14 @@ msgid "Tax amount sign"
 msgstr ""
 
 #. module: l10n_it_vat_registries
-#: code:addons/l10n_it_vat_registries/vat_registry.py:239
+#: code:addons/l10n_it_vat_registries/vat_registry.py:240
 #, python-format
 msgid "Tax code %s is not linked to 1 and only 1 tax"
 msgstr ""
 
 #. module: l10n_it_vat_registries
-#: view:website:l10n_it_vat_registries.report_registro_iva
-msgid "Totale"
+#: model:ir.ui.menu,name:l10n_it_vat_registries.menu_finance_legal_statement_taxes
+msgid "Taxes"
 msgstr ""
 
 #. module: l10n_it_vat_registries

--- a/l10n_it_vat_registries/wizard/print_registro_iva.xml
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.xml
@@ -14,7 +14,7 @@
                         <separator string="Journals" colspan="4"/>
                         <field name="tax_registry_id"></field>
                         <field name="journal_ids" colspan="4" nolabel="1" height="250" domain="[('type', 'in', ('sale','purchase','sale_refund','purchase_refund'))]"/>
-                        <separator string="Layuot" colspan="4"/>
+                        <separator string="Layout" colspan="4"/>
                         <field name="type"/>
                         <field name="tax_sign" />
                         <field name="only_totals" />

--- a/l10n_it_vat_registries/wizard/print_registro_iva.xml
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.xml
@@ -41,8 +41,13 @@
         </record>
 
         <menuitem
+          id="menu_finance_legal_statement_taxes"
+          name="Taxes"
+          parent="account.menu_finance_legal_statement"/>
+
+        <menuitem
             name="VAT Registries"
-            parent="account.menu_finance_reporting"
+            parent="menu_finance_legal_statement_taxes"
             action="action_registro_iva"
             id="menu_registro_iva"
             icon="STOCK_PRINT"/>


### PR DESCRIPTION
I moved the vat registries report menu item under Accounting > Reporting > Legal Reports > Taxes just because the main reporting menu is mainly used for statistics and bi views
