### PR TITLE
	modified:   l10n_it_vat_registries/models/account_tax_registry.py

### DIFF
--- a/l10n_it_vat_registries/models/account_tax_registry.py
+++ b/l10n_it_vat_registries/models/account_tax_registry.py
@@ -15,7 +15,7 @@ class AccountTaxRegistry(models.Model):
             'account.tax.registry'))
     journal_ids = fields.One2many(
         'account.journal', 'tax_registry_id', 'Journals', readonly=True)
-    type = fields.Selection([
+    layout_type = fields.Selection([
         ('customer', 'Customer Invoices'),
         ('supplier', 'Supplier Invoices'),
         ('corrispettivi', 'Corrispettivi'),

--- a/l10n_it_vat_registries/tests/test_registry.py
+++ b/l10n_it_vat_registries/tests/test_registry.py
@@ -56,7 +56,7 @@ class TestRegistry(AccountingTestCase):
         wizard = self.env['wizard.registro.iva'].create({
             'from_date': fields.Date.today(),
             'to_date': fields.Date.today(),
-            'type': 'supplier',
+            'layout_type': 'supplier',
             'journal_ids': [(6, 0, [self.journal.id])],
             'fiscal_page_base': 0,
         })

--- a/l10n_it_vat_registries/views/account_tax_registry_view.xml
+++ b/l10n_it_vat_registries/views/account_tax_registry_view.xml
@@ -8,7 +8,7 @@
                 <form>
                     <group>
                         <field name="name"></field>
-                        <field name="type"></field>
+                        <field name="layout_type"></field>
                     </group>
                     <separator string="Journals"></separator>
                     <field name="journal_ids"></field>

--- a/l10n_it_vat_registries/wizard/print_registro_iva.py
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.py
@@ -15,7 +15,7 @@ class WizardRegistroIva(models.TransientModel):
     date_range_id = fields.Many2one('date.range', string="Date range")
     from_date = fields.Date('From date', required=True)
     to_date = fields.Date('To date', required=True)
-    type = fields.Selection([
+    layout_type = fields.Selection([
         ('customer', 'Customer Invoices'),
         ('supplier', 'Supplier Invoices'),
         ('corrispettivi', 'Corrispettivi'),
@@ -38,6 +38,7 @@ class WizardRegistroIva(models.TransientModel):
     @api.onchange('tax_registry_id')
     def on_change_vat_registry(self):
         self.journal_ids = self.tax_registry_id.journal_ids
+        self.layout_type = self.tax_registry_id.layout_type
 
     @api.onchange('date_range_id')
     def on_change_date_range_id(self):
@@ -60,7 +61,7 @@ class WizardRegistroIva(models.TransientModel):
         datas_form['to_date'] = wizard.to_date
         datas_form['journal_ids'] = [j.id for j in wizard.journal_ids]
         datas_form['fiscal_page_base'] = wizard.fiscal_page_base
-        datas_form['registry_type'] = wizard.type
+        datas_form['registry_type'] = wizard.layout_type
         list_id = []
         for move in move_ids:
             list_id.append(move.id)

--- a/l10n_it_vat_registries/wizard/print_registro_iva.xml
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.xml
@@ -20,7 +20,7 @@
                         <field name="tax_registry_id"></field>
                         <field name="journal_ids" colspan="2" nolabel="1" height="250" domain="[('type', 'in', ('sale','purchase'))]"/>
                         <separator string="Layout" colspan="2"/>
-                        <field name="type"/>
+                        <field name="layout_type"/>
                         <field name="only_totals" />
                         <field name="fiscal_page_base"/>
                         <newline/>


### PR DESCRIPTION
-       modified:   l10n_it_vat_registries/tests/test_registry.py
- 	modified:   l10n_it_vat_registries/views/account_tax_registry_view.xml
- 	modified:   l10n_it_vat_registries/wizard/print_registro_iva.py
- 	modified:   l10n_it_vat_registries/wizard/print_registro_iva.xml

- modificato il metodo on_change, del wizard di stampa, in modo tale che al cambiare di registro iva scelto, venga aggiornato il corrispondente layout di stampa registro in automatico
- rinominato la variabile del registro fattura "type", in quanto anche se non una keyword riservata, è ufficialmente una built-in function: https://docs.python.org/2.7/library/functions.html#type . (allibito che anche Odoo in invoice usi la variabile type...)