### PR TITLE
Calcolo prezzo e sconto nell'inserimento di una nuova riga

### DIFF
--- a/l10n_it_ddt/__manifest__.py
+++ b/l10n_it_ddt/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     'name': 'DDT',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'category': 'Localization/Italy',
     'summary': 'Documento di Trasporto',
     'author': 'Davide Corio, Odoo Community Association (OCA),'

--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -106,6 +106,10 @@ class StockPickingPackagePreparation(models.Model):
         help="This depends on 'To be Invoiced' field of the Reason for "
              "Transportation of this DDT")
     show_price = fields.Boolean(string='Show prices on report')
+    weight_manual = fields.Float(
+        string="Force Weight",
+        help="Fill this field with the value you want to be used as weight. "
+             "Leave empty to let the system to compute it")
 
     @api.onchange('partner_id', 'ddt_type_id')
     def on_change_partner(self):
@@ -183,11 +187,14 @@ class StockPickingPackagePreparation(models.Model):
                  'package_id.quant_ids',
                  'picking_ids',
                  'picking_ids.move_lines',
-                 'picking_ids.move_lines.quant_ids')
+                 'picking_ids.move_lines.quant_ids',
+                 'weight_manual')
     def _compute_weight(self):
         super(StockPickingPackagePreparation, self)._compute_weight()
         for prep in self:
-            if not prep.package_id:
+            if prep.weight_manual:
+                prep.weight = prep.weight_manual
+            elif not prep.package_id:
                 quants = self.env['stock.quant']
                 for picking in prep.picking_ids:
                     for line in picking.move_lines:

--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -291,7 +291,8 @@ class StockPickingPackagePreparation(models.Model):
             elif group_method == 'shipping_partner':
                 group_key = (ddt.partner_id.id, ddt.company_id.currency_id.id)
             elif group_method == 'code_group':
-                group_key = (ddt.partner_id.ddt_code_group)
+                group_key = (ddt.partner_id.ddt_code_group,
+                             order.partner_invoice_id.id)
             else:
                 group_key = ddt.id
 

--- a/l10n_it_ddt/tests/test_ddt.py
+++ b/l10n_it_ddt/tests/test_ddt.py
@@ -373,6 +373,8 @@ class TestDdt(TransactionCase):
         ddt.set_done()
         self.assertTrue('DDT' in ddt.display_name)
         self.assertEqual(ddt.weight, 0)
+        ddt.weight_manual = 10
+        self.assertEqual(ddt.weight, 10)
 
     def test_partial_pick(self):
         order1 = self._create_sale_order()

--- a/l10n_it_ddt/views/stock_picking_package_preparation.xml
+++ b/l10n_it_ddt/views/stock_picking_package_preparation.xml
@@ -92,6 +92,7 @@
                                attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
                         <field name="volume"/>
                         <field name="weight"/>
+                        <field name="weight_manual"/>
                         <field name="show_price"/>
                     </group>
                 </page>

--- a/l10n_it_ddt/wizard/ddt_invoicing.py
+++ b/l10n_it_ddt/wizard/ddt_invoicing.py
@@ -35,7 +35,9 @@ class DdtInvoicing(models.TransientModel):
             view = self.env['ir.model.data'].get_object_reference(
                 'l10n_it_ddt', 'view_ddt_create_invoice')
 
-            self = self.with_context(active_ids=ddts.ids)
+            self = self.with_context(active_ids=ddts.ids,
+                                     ddt_date_from=wizard.date_from,
+                                     ddt_date_to=wizard.date_to)
             return {
                     'name': _('DDT Invoicing'),
                     'context': self._context,


### PR DESCRIPTION
Calcolo prezzo e sconto nell'inserimento di una nuova riga.
E' importante dare la possibilità di aggiungere nuovi prodotti gestendone anche il prezzo da usare in fase di fatturazione.
E' il caso delle spese di trasporto.
Vengono fatte pagare in base al nr delle spedizioni e comunque si lascia la possibilità all'utente di gestirle manualmente.