### PR TITLE
[FIX] l10n_it_fatturapa_in Fattura elettronica TD01 con totale negativo

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -323,7 +323,9 @@ class AccountInvoice(models.Model):
         for line in self.invoice_line_ids:
             if line.price_unit >= 0:
                 return
-        # if every line is negative, change them all
+        # if every line is negative, change them all, and change move type
+        if self.fiscal_document_type_id.code == "TD01":
+            self.move_type = "in_refund"
         for line in self.invoice_line_ids:
             line = line.with_context(check_move_validity=False)
             line.update({"price_unit": -line.price_unit})

--- a/l10n_it_fatturapa_in/tests/data/IT02098391200_FPR16.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT02098391200_FPR16.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FatturaElettronica xmlns="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12">
+
+  <FatturaElettronicaHeader xmlns="">
+
+    <DatiTrasmissione>
+
+      <IdTrasmittente>
+
+        <IdPaese>IT</IdPaese>
+        <IdCodice>05979361218</IdCodice>
+
+      </IdTrasmittente>
+      <ProgressivoInvio>56Fvy</ProgressivoInvio>
+      <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+      <CodiceDestinatario>0000000</CodiceDestinatario>
+
+    </DatiTrasmissione>
+    <CedentePrestatore>
+
+      <DatiAnagrafici>
+
+        <IdFiscaleIVA>
+
+          <IdPaese>IT</IdPaese>
+          <IdCodice>02780790107</IdCodice>
+
+        </IdFiscaleIVA>
+        <CodiceFiscale>02780790107</CodiceFiscale>
+        <Anagrafica>
+
+          <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+
+        </Anagrafica>
+        <RegimeFiscale>RF01</RegimeFiscale>
+
+      </DatiAnagrafici>
+      <Sede>
+
+        <Indirizzo>VIALE ROMA 543</Indirizzo>
+        <CAP>07100</CAP>
+        <Comune>SASSARI</Comune>
+        <Provincia>SS</Provincia>
+        <Nazione>IT</Nazione>
+
+      </Sede>
+
+    </CedentePrestatore>
+    <CessionarioCommittente>
+
+      <DatiAnagrafici>
+        <CodiceFiscale>03533590174</CodiceFiscale>
+        <Anagrafica>
+          <Denominazione>BETA GAMMA</Denominazione>
+        </Anagrafica>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIA TORINO 38-B</Indirizzo>
+        <CAP>00145</CAP>
+        <Comune>ROMA</Comune>
+        <Provincia>RM</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+
+    </CessionarioCommittente>
+  </FatturaElettronicaHeader>
+  <FatturaElettronicaBody xmlns="">
+
+    <DatiGenerali>
+
+      <DatiGeneraliDocumento>
+
+        <TipoDocumento>TD01</TipoDocumento>
+        <Divisa>EUR</Divisa>
+        <Data>2023-01-23</Data>
+        <Numero>2023/131703/1</Numero>
+        <ImportoTotaleDocumento>-1.83</ImportoTotaleDocumento>
+        <Causale>LA FATTURA FA RIFERIMENTO AD UNA OPERAZIONE AAAA BBBBBBBBBBBBBBBBBB CCC DDDDDDDDDDDDDDD E FFFFFFFFFFFFFFFFFFFF GGGGGGGGGG HHHHHHH II LLLLLLLLLLLLLLLLL MMM NNNNN OO PPPPPPPPPPP QQQQ RRRR SSSSSSSSSSSSSS</Causale>
+        <Causale>SEGUE DESCRIZIONE CAUSALE NEL CASO IN CUI NON SIANO STATI SUFFICIENTI 200 CARATTERI AAAAAAAAAAA BBBBBBBBBBBBBBBBB</Causale>
+
+      </DatiGeneraliDocumento>
+
+    </DatiGenerali>
+    <DatiBeniServizi>
+      <DettaglioLinee>
+
+        <NumeroLinea>10</NumeroLinea>
+        <Descrizione>Quota fissa Fognatura</Descrizione>
+        <Quantita>10.00</Quantita>
+        <DataInizioPeriodo>2022-01-01</DataInizioPeriodo>
+        <DataFinePeriodo>2022-04-19</DataFinePeriodo>
+        <PrezzoUnitario>-0.15</PrezzoUnitario>
+        <PrezzoTotale>-1.50</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+
+      </DettaglioLinee>
+
+      <DatiRiepilogo>
+
+        <AliquotaIVA>22.00</AliquotaIVA>
+        <ImponibileImporto>-1.50</ImponibileImporto>
+        <Imposta>-0.33</Imposta>
+        <EsigibilitaIVA>I</EsigibilitaIVA>
+        <RiferimentoNormativo>IVA al 22%</RiferimentoNormativo>
+
+      </DatiRiepilogo>
+
+    </DatiBeniServizi>
+    <DatiPagamento>
+
+      <CondizioniPagamento>TP02</CondizioniPagamento>
+      <DettaglioPagamento>
+
+        <ModalitaPagamento>MP19</ModalitaPagamento>
+        <DataScadenzaPagamento>2023-02-22</DataScadenzaPagamento>
+        <ImportoPagamento>0.00</ImportoPagamento>
+
+      </DettaglioPagamento>
+
+    </DatiPagamento>
+  </FatturaElettronicaBody>
+
+</FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -984,6 +984,20 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
             ),
         )
 
+    def test_54_xml_import(self):
+        '''
+        Test: Negative invoice (TD01) is correctly imported, converted all values to positive and set move_type to in_refund
+        '''
+        res = self.run_wizard("test54", "IT02098391200_FPR16.xml")
+        invoice_id = res.get("domain")[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertEqual(invoice.amount_untaxed, 1.5)
+        self.assertEqual(invoice.amount_total, 1.83)
+        self.assertEqual(invoice.invoice_line_ids[0].price_unit, 0.15)
+        self.assertEqual(invoice.invoice_line_ids[0].quantity, 10.0)
+        self.assertEqual(invoice.invoice_line_ids[0].price_subtotal, 1.5)
+        self.assertEqual(invoice.move_type, "in_refund")
+
     def test_01_xml_link(self):
         """
         E-invoice lines are created.


### PR DESCRIPTION
Modifica per [#3751](https://github.com/OCA/l10n-italy/pull/3751)

Al controllo delle righe, se sono tutte quante negative e il tipo di documento è TD01, imposta il move_type a 'in_refund' (nota di credito)